### PR TITLE
fix: update mergeprops usage to avoid losing props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,8 +70,11 @@ function connectForm(formName, formSelector, validators = []) {
     };
 
     const mergeProps = validators && validators.length
-        ? ({ model }) => ({
-            modelValidity: validateModel(model)
+        ? (stateProps, dispatchProps, ownProps = {}) => ({
+            modelValidity: validateModel(stateProps.model),
+            ...stateProps,
+            ...dispatchProps,
+            ...ownProps
         })
         : undefined;
 


### PR DESCRIPTION
Seems like `model` and all the actions are being dropped because the return from `mergeProps` excludes them and just returns `modelValidity`. Props passed from the parent component were also lost. This change works makes everything work as I expected it to